### PR TITLE
Brokering Registration and Brokering Permits

### DIFF
--- a/_strategic-goods-permit-and-reg-req/Permit and Registration Requirements/brokering.md
+++ b/_strategic-goods-permit-and-reg-req/Permit and Registration Requirements/brokering.md
@@ -25,7 +25,7 @@ You should register as a broker with Singapore Customs at least 14 working days 
 
 In addition, registered brokers are required to submit a  [half-yearly report on brokering activities](/eservices/customs-forms-and-service-links)  that have been carried out during that period. The report must be submitted to Singapore Customs by the 30th  day of June and December every year. Singapore Customs may also require the records to be audited and verified by an authorised officer at any time.
 
-Your application should be processed within seven working days. Please ensure that the information and documents provided are complete. However, some applications may take a longer time to process, depending on the nature of the item, destination or parties involved in the transaction. To avoid any possible delay in your brokering activities, you are encouraged to submit your application two months ahead for our assessment and processing. some applications may take longer to process, depending on the nature of the item, destination or parties involved in the transaction.
+Your application should be processed within seven working days. Please ensure that the information and documents provided are complete. However, some applications may take a longer time to process, depending on the nature of the item, destination or parties involved in the transaction. To avoid any possible delay in your brokering activities, you are encouraged to submit your application two months ahead for our assessment and processing. 
 
 ## Applying for a Brokering Permit
 

--- a/_strategic-goods-permit-and-reg-req/Permit and Registration Requirements/brokering.md
+++ b/_strategic-goods-permit-and-reg-req/Permit and Registration Requirements/brokering.md
@@ -1,9 +1,8 @@
 ---
 title: Brokering
-permalink: /businesses/strategic-goods-control/permit-and-registration-requirements/brokering
+permalink: /businesses/strategic-goods-control/permit-and-registration-requirements/brokering/
 third_nav_title: Permit and Registration Requirements
 ---
-
 # Brokering
 
 Brokering is the arrangement, negotiation, or the act of facilitating the arrangement or negotiation, of a contract to acquire or dispose controlled goods or technology, with reason to believe the contract will, or is likely to, result in the removal of the goods and technology from one foreign country to another.
@@ -26,7 +25,7 @@ You should register as a broker with Singapore Customs at least 14 working days 
 
 In addition, registered brokers are required to submit a  [half-yearly report on brokering activities](/eservices/customs-forms-and-service-links)  that have been carried out during that period. The report must be submitted to Singapore Customs by the 30th  day of June and December every year. Singapore Customs may also require the records to be audited and verified by an authorised officer at any time.
 
-Your application should be processed within 7 working days if the information and documents provided are complete. However, some applications may take longer to process, depending on the nature of the item, destination or parties involved in the transaction.
+Your application should be processed within seven working days. Please ensure that the information and documents provided are complete. However, some applications may take a longer time to process, depending on the nature of the item, destination or parties involved in the transaction. To avoid any possible delay in your brokering activities, you are encouraged to submit your application two months ahead for our assessment and processing. some applications may take longer to process, depending on the nature of the item, destination or parties involved in the transaction.
 
 ## Applying for a Brokering Permit
 
@@ -59,4 +58,4 @@ This applies even if the goods are not strategic goods.
 
 **Step 3:**  Submit the completed form and supporting documents.
 
-Your application should be processed within 7 working days if the information and documents provided are complete. However, some applications may take longer to process, depending on the nature of the item, destination or parties involved in the transaction.
+Your application should be processed within seven working days. Please ensure that the information and documents provided are complete. However, some applications may take a longer time to process, depending on the nature of the item, destination or parties involved in the transaction. To avoid any possible delay in your brokering activities, you are encouraged to submit your application two months ahead for our assessment and processing.


### PR DESCRIPTION
Added text to inform applicants of the need to submit brokering applications as early as 2 months before any brokering activities: 'Your application should be processed within seven working days. Please ensure that the information and documents provided are complete. However, some applications may take a longer time to process, depending on the nature of the item, destination or parties involved in the transaction. To avoid any possible delay in your brokering activities, you are encouraged to submit your application two months ahead for our assessment and processing.'