### PR TITLE
Change of FAQ link to Sabio Console

### DIFF
--- a/_businesses/National Single Window/tradenet.md
+++ b/_businesses/National Single Window/tradenet.md
@@ -23,4 +23,4 @@ TradeNet has been the focus of several academic studies since its introduction. 
 
 {:.mobile-block}
 |---|---|---|---|
-| [![](/images/tradenet/tn1.jpg)](/businesses/national-single-window/overview/what-you-need-to-know-about-tradenet) |[![](/images/tradenet/tn2.jpg)](/businesses/national-single-window/overview/TradeNet-Solution-Providers)  | [![](/images/tradenet/tn3.jpg)](/businesses/National-Single-Window/Overview/Competent-Authorities-Requirements) | [![](/images/tradenet/tn4annex.jpg) ](/businesses/National-Single-Window/Overview/Annexes) |
+| [![](/images/tradenet/tn1.jpg)](/businesses/national-single-window/overview/what-you-need-to-know-about-tradenet) |[![](/images/tradenet/tn2.jpg)](/businesses/national-single-window/overview/tradenet-solution-providers)  | [![](/images/tradenet/tn3.jpg)](/businesses/national-single-window/overview/competent-authorities-requirements) | [![](/images/tradenet/tn4annex.jpg) ](/businesses/national-single-window/overview/annexes) |

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -8,3 +8,4 @@ links:
     url: /careers/
   - title: FAQ
     url: https://va.ecitizen.gov.sg/cfp/CustomerPages/Customs/explorefaq.aspx
+faq: https://console-flex-api.ap.sabio.cloud/faq/index.aspx?p=18336588

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -6,3 +6,4 @@ social_media:
 links:
   - title: Careers
     url: /careers/
+faq: https://console-flex-api.ap.sabio.cloud/faq/index.aspx?p=18336588

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -6,5 +6,3 @@ social_media:
 links:
   - title: Careers
     url: /careers/
-  - title: FAQ
-    url: https://va.ecitizen.gov.sg/cfp/CustomerPages/Customs/explorefaq.aspx

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -8,4 +8,3 @@ links:
     url: /careers/
   - title: FAQ
     url: https://va.ecitizen.gov.sg/cfp/CustomerPages/Customs/explorefaq.aspx
-faq: https://console-flex-api.ap.sabio.cloud/faq/index.aspx?p=18336588

--- a/_eservices/customs-forms-service-links.md
+++ b/_eservices/customs-forms-service-links.md
@@ -116,7 +116,7 @@ permalink: /eservices/customs-forms-and-service-links/
 | 14. | Claimant Application by Foreign Military Forces | [Web Link ](https://form.gov.sg/62b184bfbe2196001180ad44)
 | 15. | Claimant Application by Government Agencies, SAF Camps and Affiliated Clubs | [Web Link](https://form.gov.sg/62b184bfbe2196001180ad44)
 | 16. | Claimant Application by International Organisations Supported by an Agency Other than the MFA | [Web Link ](https://form.gov.sg/62b184bfbe2196001180ad44)
-| 17. | Security Application Template | [Word Doc](https://www.customs.gov.sg/files/eservices/Security-Application-template.doc)
+| 17. | Security Application Template | [Word Doc](https://go.gov.sg/customs-security-template)
 | 18. | Security Extension Template (For New Security Lodged from 15 April 2019) | [Word Doc](https://go.gov.sg/customs-security-extension-template-ver3)
  
 [Back to Top](/eservices/customs-forms-and-service-links)

--- a/_registration-security-lodgement/Security Lodgement/how-to-lodge-security.md
+++ b/_registration-security-lodgement/Security Lodgement/how-to-lodge-security.md
@@ -39,7 +39,7 @@ Please note that the processing by your bank, finance company or insurance compa
 
 **Submit the original security to:**<br>
 Registration Unit <br>
-Procedures & Systems Branch  
+Procedures &amp; Systems Branch  
 Singapore Customs  
 55 Newton Road   
 Revenue House  
@@ -58,7 +58,7 @@ Upon receipt of the security, Singapore Customs will register the security withi
 					   3. Inform the bank that you wish to extend your guarantee under eGuarantee@Gov programme, with template reference “CUSTOMS_REG"</p>
 			<p> Once the eGuarantee has been received and successfully registered by Singapore Customs, we will send an email notification to the primary and secondary contact registered in your entity’s Customs Account as per the current notification process.</p>
 			<p> NOTE: The procedure above only applies for cases where you are amending the eGuarantee expiry date only. If you are amending the amount to be lodged, you will have to apply for a new guarantee.</p>
-			<p>For hardcopy guarantees:You may extend the expiry date of your existing security using the <a href="https://safe.menlosecurity.com/https://www.customs.gov.sg/eservices/customs-forms-and-service-links/" target="new">Security Extension Form</a>. Please note that the processing by your bank, finance company or insurance company may take up to three to four weeks. You are encouraged to submit your security extension to Singapore Customs at least two weeks before the expiry of your existing security to allow sufficient time for processing and amendments in case of discrepancies. </p>
+			<p>For hardcopy guarantees:You may extend the expiry date of your existing security using the <a href="https://go.gov.sg/customs-security-template" target="new">Security Extension Form</a>. Please note that the processing by your bank, finance company or insurance company may take up to three to four weeks. You are encouraged to submit your security extension to Singapore Customs at least two weeks before the expiry of your existing security to allow sufficient time for processing and amendments in case of discrepancies. </p>
 			<p> If you had previously applied for a hardcopy guarantee and wish to extend the validity, you will have to extend it as a hardcopy guarantee. You will NOT be able to extend it via the eGuarantee@Gov programme.</p>
 			<p>You are strongly encouraged to apply for a new guarantee under the eGuarantee@Gov programme instead of extending the validity via hardcopy guarantee.</p>
   </div>


### PR DESCRIPTION
Edit made: Change of FAQ link in the website footer to reflect the new link pointing to Sabio Console's FAQ. Previous FAQ link was removed by Shazli from the Isomer Support Team. 

For your approval, please. Thank you. 