### PR TITLE
To remove announcement posts regarding ‘Chemical Weapons Convention Licence Renewal Exercise for Year 2024’ and ‘Annual Declaration of Past Activities Exercise for Year 2023’ as the exercises have ended. 

### DIFF
--- a/_businesses/Chemical Weapons Convention (CWC)/announcement.md
+++ b/_businesses/Chemical Weapons Convention (CWC)/announcement.md
@@ -6,18 +6,6 @@ variant: markdown
 ---
 # Announcement 
  
-**5 Dec 2023**
-
-**Annual Declaration of Past Activities Exercise for Year 2023**
-
-The Annual Declaration of Past Activities (ADPA) Exercise for Year 2023 will commence from 5 Dec 2023 to 31 Jan 2024. Companies which have engaged in controlled activities involving Schedule 1, 2, 3 and Unscheduled Discrete Organic Chemicals are required to submit their ADPA by 31 Jan 2024. Please fill out the Declaration Cover for Reporting Template and the relevant declaration templates which can be accessed from the [Chemical Weapons Convention Forms section on the Customs Forms and Service Links page](https://www.customs.gov.sg/eservices/customs-forms-and-service-links).
-
-**1 Nov 2023**
-
-**Chemical Weapons Convention Licence Renewal Exercise for Year 2024**
-
-The Chemical Weapons Convention (CWC) Licence Renewal exercise for Year 2024 will commence from 1 Nov 2023 to 31 Dec 2023. Companies engaging in the controlled activities may submit the licence renewal applications by 31 Dec 2023. Please fill out the licence application forms which can be accessed from the      [Chemical Weapons Convention Forms section on the Customs Forms and Service Links page](https://www.customs.gov.sg/eservices/customs-forms-and-service-links).
-
 **18 Oct 2023**
 
  **Joint Regulatory Control of Scheduled CWC Chemicals by NEA, SCDF and NA(CWC)**


### PR DESCRIPTION
Announcement posts are scheduled to be removed from the website, immediately upon Ccoms approval as both exercises have ended.

