### PR TITLE
Amendment to Singapore Trade Security Page 

### DIFF
--- a/_businesses/trade-security-in-singapore.md
+++ b/_businesses/trade-security-in-singapore.md
@@ -74,5 +74,4 @@ Under Section 45 of the Corruption, Drug Trafficking and Other Serious Crimes (C
 
 Traders also have the duty to provide information on property and financial transactions belonging to terrorist and acts of terrorism-financing under Sections 8 and 10 of the Terrorism (Suppression of Financing) Act 2002 to the Police or to do so via a STR. Failure to do so may constitute a criminal offence.
 
-Traders may refer to the red flag indicators for Zero-GST warehouse licensees [here](  
-https://www.police.gov.sg/-/media/Spf/Advisories/TradeZeroGSTRatedLicensedWarehousesIndicators.ashx) to detect and file a STR with the STRO.
+Traders may refer to the Trade-Based Money Laundering [risk indicators](/files/FATF.pdf) to detect suspicious trade activities  and file a STR with the STRO.


### PR DESCRIPTION
Amended content and add TBML risk indicators pdf to hyperlink 'risk indicators'

Traders may refer to the Trade-Based Money Laundering [risk indicators](https://staging.d2y2jvgj8f3vk2.amplifyapp.com/files/FATF.pdf) to detect suspicious trade activities and file a STR with the STRO.