### PR TITLE
Remove liner to avoid confusion

### DIFF
--- a/_import-certificate-and-delivery-verification/Import Certificate and Delivery Verification/import-certificate.md
+++ b/_import-certificate-and-delivery-verification/Import Certificate and Delivery Verification/import-certificate.md
@@ -100,7 +100,6 @@ If you did _not_ indicate  in your IC application that the goods are for re-expo
 **Note:**
 
 -   You should obtain a strategic goods permit if you are re-exporting  [strategic goods](/businesses/strategic-goods-control/strategic-goods-control-list). Read about [strategic goods permit requirements](/businesses/strategic-goods-control/permit-and-registration-requirements/individual-permit-export-transhipment-and-transit).
--   If goods imported under the IC remain in the Free Trade Zone while pending re-export, you should still obtain both import and export permits.
 
 ## Notifying Changes and Transferring Ownership
 


### PR DESCRIPTION
Strategic Goods Control Branch, PSB reviewed the information on the [Import Certificate](https://www.customs.gov.sg/businesses/strategic-goods-control/import-certificate-and-delivery-verification/import-certificate/) (IC) website, particularly on this liner which mentioned that “If goods imported under the IC remain in the Free Trade Zone while pending re-export, you should still obtain both import and export permits.” 

Since (a) goods to be imported under an IC are seldom first stored in the FTZ and;
(b) the sentence may give readers the wrong impression that goods under an IC can be re-exported directly out from the FTZ without entering Customs territory, we propose removing the line in red.