### PR TITLE
One of the links on this webpage was flagged out as a broken link by WOGAA.

### DIFF
--- a/_import-certificate-and-delivery-verification/Import Certificate and Delivery Verification/import-certificate.md
+++ b/_import-certificate-and-delivery-verification/Import Certificate and Delivery Verification/import-certificate.md
@@ -99,7 +99,7 @@ If you did _not_ indicate  in your IC application that the goods are for re-expo
 
 **Note:**
 
--   You should obtain a strategic goods permit if you are re-exporting  [strategic goods](/businesses/strategic-goods-control/strategic-goods-control-list). Read about [strategic goods permit requirements](/businesses/strategic-goods-control/permit-and-registration-requirements/individual-permit-export-transhipment-and-transit).
+-   You should obtain a strategic goods permit if you are re-exporting  [strategic goods](/businesses/strategic-goods-control/strategic-goods-control-list). Read about [strategic goods permit requirements](https://www.customs.gov.sg/individual-permit-export-transhipment-and-transit/).
 
 ## Notifying Changes and Transferring Ownership
 


### PR DESCRIPTION
One of the links on this webpage (under subhead: Re-exporting Goods from Singapore) was flagged out as a broken link by WOGAA. Refer to the statement below.

"Note:
•	You should obtain a strategic goods permit if you are re-exporting [strategic goods](https://www.customs.gov.sg/businesses/strategic-goods-control/strategic-goods-control-list).

 Read about [strategic goods permit requirements](https://www.customs.gov.sg/businesses/strategic-goods-control/permit-and-registration-requirements/individual-permit-export-transhipment-and-transit). <-Broken link

To replace this current broken link with 
https://www.customs.gov.sg/individual-permit-export-transhipment-and-transit/
as confirmed by SGC unit..