### PR TITLE
New announcement to update licensees regarding the CWC Licence Renewal Exercise for Year 2025.

### DIFF
--- a/_businesses/Chemical Weapons Convention (CWC)/announcement.md
+++ b/_businesses/Chemical Weapons Convention (CWC)/announcement.md
@@ -6,8 +6,15 @@ variant: markdown
 ---
 # Announcement 
  
- **18 Oct 2023**
+**1 Nov 2024**
 
- **Joint Regulatory Control of Scheduled CWC Chemicals by NEA, SCDF and NA(CWC)**
+**Chemical Weapons Convention Licence Renewal Exercise for Year 2025**
+
+The Chemical Weapons Convention (CWC) Licence Renewal Exercise for Year 2025 will commence from 1 Nov 2024 to 31 Dec 2024. Companies engaging in the controlled activities may submit the licence renewal applications by 31 Dec 2024. Please fill out the licence application forms which can be accessed from the Chemical Weapons Convention Forms section on the [Customs Forms and Service Links page](https://www.customs.gov.sg/eservices/customs-forms-and-service-links).
+
+
+**18 Oct 2023**
+
+**Joint Regulatory Control of Scheduled CWC Chemicals by NEA, SCDF and NA(CWC)**
 
 With effect from 21 Aug 2023, Singapore Customs will be co-regulating 47 scheduled CWC Chemicals with the National Environment Agency (NEA) and the Singapore Civil Defence Force (SCDF). Companies that perform controlled activities involving Scheduled CWC Chemicals which exceed the exemption threshold quantities or purities must obtain a licence/permit with NEA/SCDF. Click [here](https://www.customs.gov.sg/news-and-media/competent-authorities-circulars/) for more information on the Joint Regulatory Control and the contact point(s) for both NEA/SCDF.


### PR DESCRIPTION
This amendment is to post a new announcement to update licensees regarding the CWC Licence Renewal Exercise for Year 2025. The post is scheduled to be up on 1 Nov 2024 by 10am.